### PR TITLE
Declare functions inside `extern "C"`

### DIFF
--- a/rust-demangle.h
+++ b/rust-demangle.h
@@ -3,8 +3,16 @@
 
 #define RUST_DEMANGLE_FLAG_VERBOSE 1
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 bool rust_demangle_with_callback(
     const char *mangled, int flags,
     void (*callback)(const char *data, size_t len, void *opaque), void *opaque
 );
 char *rust_demangle(const char *mangled, int flags);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This is needed to include this header from C++.