### PR TITLE
Implement const generics and allow .llvm.<hash> suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ The current port status by category is:
       * arguably backported to Rust, as the C port always took this approach
     * `min_const_generics` constants (`bool`, `char`, negative signed integers)
       * this arguably also includes `p` as an *untyped* placeholder constant
+    * [`str` and structural constants](https://github.com/rust-lang/rfcs/pull/3161)
+      (only usable in `const` generics on unstable Rust)
   * **(UNPORTED)** symbol prefix flexibility (`__R` and `R`, instead of `_R`)
-  * **(UNPORTED)** [`str` and structural constants](https://github.com/rust-lang/rfcs/pull/3161)
-    (only usable in `const` generics on unstable Rust)
   * **(UNPORTED)** recursion limits
 * miscellaneous
   * **ported** PRs:

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ The current port status by category is:
     * [[#26] v0: allow identifiers to start with a digit.](https://github.com/rust-lang/rustc-demangle/pull/26)
     * [[#53] v0: replace `skip_*` methods with `print_*` methods in a "skip printing" mode.](https://github.com/rust-lang/rustc-demangle/pull/53)
       * arguably backported to Rust, as the C port always took this approach
+    * symbol prefix flexibility (`__R` and `R`, instead of `_R`)
     * `min_const_generics` constants (`bool`, `char`, negative signed integers)
       * this arguably also includes `p` as an *untyped* placeholder constant
     * [`str` and structural constants](https://github.com/rust-lang/rfcs/pull/3161)
       (only usable in `const` generics on unstable Rust)
-  * **(UNPORTED)** symbol prefix flexibility (`__R` and `R`, instead of `_R`)
   * **(UNPORTED)** recursion limits
 * miscellaneous
   * **ported** PRs:

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ The current port status by category is:
     * [[#53] v0: replace `skip_*` methods with `print_*` methods in a "skip printing" mode.](https://github.com/rust-lang/rustc-demangle/pull/53)
       * arguably backported to Rust, as the C port always took this approach
     * symbol prefix flexibility (`__R` and `R`, instead of `_R`)
-    * `min_const_generics` constants (`bool`, `char`, negative signed integers)
-      * this arguably also includes `p` as an *untyped* placeholder constant
-    * [`str` and structural constants](https://github.com/rust-lang/rfcs/pull/3161)
+    * [[#39] Add support for `min_const_generics` constants](https://github.com/rust-lang/rustc-demangle/pull/39)
+      * [[#40] Elide the type when the const value is a placeholder `p`](https://github.com/rust-lang/rustc-demangle/pull/40)
+    * [[#55] v0: demangle structural constants and &str.](https://github.com/rust-lang/rustc-demangle/pull/55)
       (only usable in `const` generics on unstable Rust)
   * **(UNPORTED)** recursion limits
 * miscellaneous
   * **ported** PRs:
-    * extraneous symbol suffix (e.g. `.llvm.*`) removal
+    * [[#30] v0: also support preserving extra suffixes found after mangled symbol.](https://github.com/rust-lang/rustc-demangle/pull/30)
   * **(UNPORTED)** output size limits
 
 Notable differences (intentionally) introduced by porting:

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ The current port status by category is:
     * [[#26] v0: allow identifiers to start with a digit.](https://github.com/rust-lang/rustc-demangle/pull/26)
     * [[#53] v0: replace `skip_*` methods with `print_*` methods in a "skip printing" mode.](https://github.com/rust-lang/rustc-demangle/pull/53)
       * arguably backported to Rust, as the C port always took this approach
+    * `min_const_generics` constants (`bool`, `char`, negative signed integers)
+      * this arguably also includes `p` as an *untyped* placeholder constant
   * **(UNPORTED)** symbol prefix flexibility (`__R` and `R`, instead of `_R`)
-  * **(UNPORTED)** `min_const_generics` constants (`bool`, `char`, negative signed integers)
-    * this arguably also includes `p` as an *untyped* placeholder constant
   * **(UNPORTED)** [`str` and structural constants](https://github.com/rust-lang/rfcs/pull/3161)
     (only usable in `const` generics on unstable Rust)
   * **(UNPORTED)** recursion limits

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ The current port status by category is:
     (only usable in `const` generics on unstable Rust)
   * **(UNPORTED)** recursion limits
 * miscellaneous
-  * **(UNPORTED)** extraneous symbol suffix (e.g. `.llvm.*`) removal
+  * **ported** PRs:
+    * extraneous symbol suffix (e.g. `.llvm.*`) removal
   * **(UNPORTED)** output size limits
 
 Notable differences (intentionally) introduced by porting:

--- a/rust-demangle.c
+++ b/rust-demangle.c
@@ -428,6 +428,7 @@ static void demangle_path(struct rust_demangler *rdm, bool in_value) {
         rdm->skipping_printing = true;
         demangle_path(rdm, in_value);
         rdm->skipping_printing = was_skipping_printing;
+        __attribute__((fallthrough));
     case 'Y':
         PRINT("<");
         demangle_type(rdm);
@@ -569,7 +570,7 @@ static void demangle_type(struct rust_demangler *rdm) {
         }
         PRINT("]");
         break;
-    case 'T':
+    case 'T': {
         PRINT("(");
         size_t i;
         for (i = 0; !rdm->errored && !eat(rdm, 'E'); i++) {
@@ -581,6 +582,7 @@ static void demangle_type(struct rust_demangler *rdm) {
             PRINT(",");
         PRINT(")");
         break;
+    }
     case 'F': {
         uint64_t old_bound_lifetime_depth = rdm->bound_lifetime_depth;
         demangle_binder(rdm);

--- a/rust-demangle.c
+++ b/rust-demangle.c
@@ -892,7 +892,7 @@ static void demangle_const(struct rust_demangler *rdm, bool in_value) {
     case 'Q':
         if (ty_tag == 'R' && eat(rdm, 'e')) {
             // NOTE(eddyb) this prints `"..."` instead of `&*"..."`, which
-                // is what `Re..._` would imply (see comment for `str` above).
+            // is what `Re..._` would imply (see comment for `str` above).
             demangle_const_str_literal(rdm);
             break;
         }

--- a/rust-demangle.c
+++ b/rust-demangle.c
@@ -182,7 +182,8 @@ static void print_uint64_hex(struct rust_demangler *rdm, uint64_t x) {
     PRINT(s);
 }
 
-static void print_quoted_escaped_char(struct rust_demangler *rdm, char quote, uint32_t c) {
+static void
+print_quoted_escaped_char(struct rust_demangler *rdm, char quote, uint32_t c) {
     switch (c) {
     case '\0':
         PRINT("\\0");
@@ -251,12 +252,12 @@ print_ident(struct rust_demangler *rdm, struct rust_mangled_ident ident) {
     while (cap < ident.ascii_len) {
         cap *= 2;
         // Check for overflows.
-        CHECK_OR((cap * 4) / 4 == cap, return );
+        CHECK_OR((cap * 4) / 4 == cap, return);
     }
 
     // Store the output codepoints as groups of 4 UTF-8 bytes.
     uint8_t *out = (uint8_t *)malloc(cap * 4);
-    CHECK_OR(out, return );
+    CHECK_OR(out, return);
 
     // Populate initial output from ASCII fragment.
     for (len = 0; len < ident.ascii_len; len++) {
@@ -404,7 +405,7 @@ static void demangle_const_str_literal(struct rust_demangler *rdm);
 /// printing e.g. `for<'a, 'b> `, and make those lifetimes visible
 /// to the caller (via depth level, which the caller should reset).
 static void demangle_binder(struct rust_demangler *rdm) {
-    CHECK_OR(!rdm->errored, return );
+    CHECK_OR(!rdm->errored, return);
 
     uint64_t bound_lifetimes = parse_opt_integer_62(rdm, 'G');
     if (bound_lifetimes > 0) {
@@ -420,7 +421,7 @@ static void demangle_binder(struct rust_demangler *rdm) {
 }
 
 static void demangle_path(struct rust_demangler *rdm, bool in_value) {
-    CHECK_OR(!rdm->errored, return );
+    CHECK_OR(!rdm->errored, return);
 
     char tag = next(rdm);
     switch (tag) {
@@ -438,7 +439,7 @@ static void demangle_path(struct rust_demangler *rdm, bool in_value) {
     }
     case 'N': {
         char ns = next(rdm);
-        CHECK_OR(IS_LOWER(ns) || IS_UPPER(ns), return );
+        CHECK_OR(IS_LOWER(ns) || IS_UPPER(ns), return);
 
         demangle_path(rdm, in_value);
 
@@ -516,7 +517,7 @@ static void demangle_path(struct rust_demangler *rdm, bool in_value) {
         break;
     }
     default:
-        ERROR_AND(return );
+        ERROR_AND(return);
     }
 }
 
@@ -581,7 +582,7 @@ static const char *basic_type(char tag) {
 }
 
 static void demangle_type(struct rust_demangler *rdm) {
-    CHECK_OR(!rdm->errored, return );
+    CHECK_OR(!rdm->errored, return);
 
     char tag = next(rdm);
 
@@ -709,7 +710,7 @@ static void demangle_type(struct rust_demangler *rdm) {
         // Restore `bound_lifetime_depth` to outside the binder.
         rdm->bound_lifetime_depth = old_bound_lifetime_depth;
 
-        CHECK_OR(eat(rdm, 'L'), return );
+        CHECK_OR(eat(rdm, 'L'), return);
         uint64_t lt = parse_integer_62(rdm);
         if (lt) {
             PRINT(" + ");
@@ -766,7 +767,7 @@ static bool demangle_path_maybe_open_generics(struct rust_demangler *rdm) {
 }
 
 static void demangle_dyn_trait(struct rust_demangler *rdm) {
-    CHECK_OR(!rdm->errored, return );
+    CHECK_OR(!rdm->errored, return);
 
     bool open = demangle_path_maybe_open_generics(rdm);
 
@@ -788,7 +789,7 @@ static void demangle_dyn_trait(struct rust_demangler *rdm) {
 }
 
 static void demangle_const(struct rust_demangler *rdm, bool in_value) {
-    CHECK_OR(!rdm->errored, return );
+    CHECK_OR(!rdm->errored, return);
 
     bool opened_brace = false;
 
@@ -832,7 +833,7 @@ static void demangle_const(struct rust_demangler *rdm, bool in_value) {
             else if (c >= 'a' && c <= 'f')
                 value |= 10 + (c - 'a');
             else
-                ERROR_AND(return );
+                ERROR_AND(return);
             hex_len++;
         }
 
@@ -841,7 +842,7 @@ static void demangle_const(struct rust_demangler *rdm, bool in_value) {
         } else if (value == 1) {
             PRINT("true");
         } else {
-            ERROR_AND(return );
+            ERROR_AND(return);
         }
         break;
     }
@@ -858,15 +859,15 @@ static void demangle_const(struct rust_demangler *rdm, bool in_value) {
             else if (c >= 'a' && c <= 'f')
                 value |= 10 + (c - 'a');
             else
-                ERROR_AND(return );
+                ERROR_AND(return);
             hex_len++;
         }
 
         if (value >= 0x10FFFF)
-            ERROR_AND(return );
+            ERROR_AND(return);
 
         if (value >= 0xD800 && value <= 0xDFFF)
-            ERROR_AND(return );
+            ERROR_AND(return);
 
         PRINT("'");
         print_quoted_escaped_char(rdm, '\'', value);
@@ -920,7 +921,7 @@ static void demangle_const(struct rust_demangler *rdm, bool in_value) {
 
         size_t i = 0;
         while (!eat(rdm, 'E')) {
-            CHECK_OR(!rdm->errored, return );
+            CHECK_OR(!rdm->errored, return);
 
             if (i > 0)
                 PRINT(", ");
@@ -944,7 +945,7 @@ static void demangle_const(struct rust_demangler *rdm, bool in_value) {
 
         size_t i = 0;
         while (!eat(rdm, 'E')) {
-            CHECK_OR(!rdm->errored, return );
+            CHECK_OR(!rdm->errored, return);
 
             if (i > 0)
                 PRINT(", ");
@@ -978,7 +979,7 @@ static void demangle_const(struct rust_demangler *rdm, bool in_value) {
 
             size_t i = 0;
             while (!eat(rdm, 'E')) {
-                CHECK_OR(!rdm->errored, return );
+                CHECK_OR(!rdm->errored, return);
 
                 if (i > 0)
                     PRINT(", ");
@@ -997,7 +998,7 @@ static void demangle_const(struct rust_demangler *rdm, bool in_value) {
 
             size_t i = 0;
             while (!eat(rdm, 'E')) {
-                CHECK_OR(!rdm->errored, return );
+                CHECK_OR(!rdm->errored, return);
 
                 if (i > 0)
                     PRINT(", ");
@@ -1019,7 +1020,7 @@ static void demangle_const(struct rust_demangler *rdm, bool in_value) {
         }
 
         default:
-            ERROR_AND(return );
+            ERROR_AND(return);
         }
 
         break;
@@ -1036,7 +1037,7 @@ static void demangle_const(struct rust_demangler *rdm, bool in_value) {
     }
 
     default:
-        ERROR_AND(return );
+        ERROR_AND(return);
     }
 
     if (opened_brace) {
@@ -1045,7 +1046,7 @@ static void demangle_const(struct rust_demangler *rdm, bool in_value) {
 }
 
 static void demangle_const_uint(struct rust_demangler *rdm, char ty_tag) {
-    CHECK_OR(!rdm->errored, return );
+    CHECK_OR(!rdm->errored, return);
 
     uint64_t value = 0;
     size_t hex_len = 0;
@@ -1058,7 +1059,7 @@ static void demangle_const_uint(struct rust_demangler *rdm, char ty_tag) {
         else if (c >= 'a' && c <= 'f')
             value |= 10 + (c - 'a');
         else
-            ERROR_AND(return );
+            ERROR_AND(return);
         hex_len++;
     }
 
@@ -1074,9 +1075,8 @@ static void demangle_const_uint(struct rust_demangler *rdm, char ty_tag) {
         PRINT(basic_type(ty_tag));
 }
 
-
 static void demangle_const_str_literal(struct rust_demangler *rdm) {
-    CHECK_OR(!rdm->errored, return );
+    CHECK_OR(!rdm->errored, return);
 
     PRINT("\"");
 
@@ -1090,7 +1090,7 @@ static void demangle_const_str_literal(struct rust_demangler *rdm) {
         else if (c >= 'a' && c <= 'f')
             value |= 10 + (c - 'a');
         else
-            ERROR_AND(return );
+            ERROR_AND(return);
 
         value <<= 4;
 
@@ -1100,7 +1100,7 @@ static void demangle_const_str_literal(struct rust_demangler *rdm) {
         else if (c >= 'a' && c <= 'f')
             value |= 10 + (c - 'a');
         else
-            ERROR_AND(return );
+            ERROR_AND(return);
 
         print_quoted_escaped_char(rdm, '"', value);
     }
@@ -1160,7 +1160,8 @@ bool rust_demangle_with_callback(
     demangle_path(&rdm, true);
 
     // Skip instantiating crate.
-    if (!rdm.errored && rdm.next < rdm.sym_len && peek(&rdm) >= 'A' && peek(&rdm) <= 'Z') {
+    if (!rdm.errored && rdm.next < rdm.sym_len && peek(&rdm) >= 'A' &&
+        peek(&rdm) <= 'Z') {
         rdm.skipping_printing = true;
         demangle_path(&rdm, false);
     }

--- a/rust-demangle.c
+++ b/rust-demangle.c
@@ -934,7 +934,7 @@ static void demangle_const(struct rust_demangler *rdm, bool in_value) {
         break;
     }
 
-    case 'T':
+    case 'T': {
         if (!in_value) {
             opened_brace = true;
             PRINT("{");
@@ -959,6 +959,7 @@ static void demangle_const(struct rust_demangler *rdm, bool in_value) {
 
         PRINT(")");
         break;
+    }
 
     case 'V':
         if (!in_value) {

--- a/rust-demangle.c
+++ b/rust-demangle.c
@@ -1111,9 +1111,16 @@ bool rust_demangle_with_callback(
     const char *mangled, int flags,
     void (*callback)(const char *data, size_t len, void *opaque), void *opaque
 ) {
-    // Rust symbols always start with _R.
+    // Rust symbols always start with R, _R or __R.
     if (mangled[0] == '_' && mangled[1] == 'R')
         mangled += 2;
+    else if (mangled[0] == 'R')
+        // On Windows, dbghelp strips leading underscores, so we accept "R..."
+        // form too.
+        mangled += 1;
+    else if (mangled[0] == '_' && mangled[1] == '_' && mangled[2] == 'R')
+        // On OSX, symbols are prefixed with an extra _
+        mangled += 3;
     else
         return false;
 

--- a/test-harness/tests/top_level.rs
+++ b/test-harness/tests/top_level.rs
@@ -238,14 +238,20 @@ fn limit_recursion() {
 }
 
 // FIXME(eddyb) port the relevant functionality to C.
-#[should_panic]
+#[ignore = "would slowly use up all RAM before being OOM-killed"]
 #[test]
-fn limit_output() {
+fn limit_output_oom_hazard() {
     assert_ends_with!(
         rust_demangle_c_test_harness::demangle("RYFG_FGyyEvRYFF_EvRYFFEvERLB_B_B_ERLRjB_B_B_")
             .to_string(),
         "{size limit reached}"
     );
+}
+
+// FIXME(eddyb) port the relevant functionality to C.
+#[should_panic]
+#[test]
+fn limit_output() {
     // NOTE(eddyb) somewhat reduced version of the above, effectively
     // `<for<...> fn()>` with a larger number of lifetimes in `...`.
     assert_ends_with!(

--- a/test-harness/tests/v0.rs
+++ b/test-harness/tests/v0.rs
@@ -5,6 +5,7 @@
 //! * `::` absolute paths -> `rust_demangle_c_test_harness::`
 //! * `#[cfg(unsupported_tests)]` was added to tests that couldn't compile
 //! * `#[ignore = "stack overflow"]` was added to tests that overflow the stack
+//! * Some tests have been split into a non-unicode and a unicode part
 //! * `#[should_panic]` was added to tests that don't pass yet
 
 use rust_demangle_c_test_harness::assert_contains;
@@ -92,8 +93,6 @@ fn demangle_const_generics_preview() {
     t_const_suffixed!("j7b_", "123", "usize");
 }
 
-// FIXME(eddyb) port the relevant functionality to C.
-#[should_panic]
 #[test]
 fn demangle_min_const_generics() {
     t_const!("p", "_");
@@ -140,8 +139,6 @@ fn demangle_const_str_unicode() {
     );
 }
 
-// FIXME(eddyb) port the relevant functionality to C.
-#[should_panic]
 // NOTE(eddyb) this uses the same strings as `demangle_const_str` and should
 // be kept in sync with it - while a macro could be used to generate both
 // `str` and `&str` tests, from a single list of strings, this seems clearer.
@@ -150,6 +147,12 @@ fn demangle_const_ref_str() {
     t_const!("Re616263_", "\"abc\"");
     t_const!("Re27_", r#""'""#);
     t_const!("Re090a_", "\"\\t\\n\"");
+}
+
+// FIXME(bjorn3) port the relevant functionality to C.
+#[should_panic]
+#[test]
+fn demangle_const_ref_unicode() {
     t_const!("Ree28882c3bc_", "\"∂ü\"");
     t_const!(
         "Ree183a1e18390e183ade1839be18394e1839ae18390e183935fe18392e18394e1839b\
@@ -163,8 +166,6 @@ fn demangle_const_ref_str() {
     );
 }
 
-// FIXME(eddyb) port the relevant functionality to C.
-#[should_panic]
 #[test]
 fn demangle_const_ref() {
     t_const!("Rp", "{&_}");
@@ -176,8 +177,6 @@ fn demangle_const_ref() {
     t_const!("QAE", "{&mut []}");
 }
 
-// FIXME(eddyb) port the relevant functionality to C.
-#[should_panic]
 #[test]
 fn demangle_const_array() {
     t_const!("AE", "{[]}");
@@ -187,8 +186,6 @@ fn demangle_const_array() {
     t_const!("AAh1_h2_EAh3_h4_EE", "{[[1, 2], [3, 4]]}");
 }
 
-// FIXME(eddyb) port the relevant functionality to C.
-#[should_panic]
 #[test]
 fn demangle_const_tuple() {
     t_const!("TE", "{()}");
@@ -200,8 +197,6 @@ fn demangle_const_tuple() {
     );
 }
 
-// FIXME(eddyb) port the relevant functionality to C.
-#[should_panic]
 #[test]
 fn demangle_const_adt() {
     t_const!(

--- a/test-harness/tests/v0.rs
+++ b/test-harness/tests/v0.rs
@@ -119,7 +119,6 @@ fn demangle_const_str() {
     t_const!("e616263_", "{*\"abc\"}");
     t_const!("e27_", r#"{*"'"}"#);
     t_const!("e090a_", "{*\"\\t\\n\"}");
-
 }
 
 // FIXME(bjorn3) port the relevant functionality to C.

--- a/test-harness/tests/v0.rs
+++ b/test-harness/tests/v0.rs
@@ -106,16 +106,27 @@ fn demangle_min_const_generics() {
     t_const!("c76_", "'v'");
     t_const!("c22_", r#"'"'"#);
     t_const!("ca_", "'\\n'");
+}
+
+// FIXME(bjorn3) port the relevant functionality to C.
+#[should_panic]
+#[test]
+fn demangle_min_const_generics_unicode() {
     t_const!("c2202_", "'∂'");
 }
 
-// FIXME(eddyb) port the relevant functionality to C.
-#[should_panic]
 #[test]
 fn demangle_const_str() {
     t_const!("e616263_", "{*\"abc\"}");
     t_const!("e27_", r#"{*"'"}"#);
     t_const!("e090a_", "{*\"\\t\\n\"}");
+
+}
+
+// FIXME(bjorn3) port the relevant functionality to C.
+#[should_panic]
+#[test]
+fn demangle_const_str_unicode() {
     t_const!("ee28882c3bc_", "{*\"∂ü\"}");
     t_const!(
         "ee183a1e18390e183ade1839be18394e1839ae18390e183935fe18392e18394e1839b\

--- a/test-harness/tests/v0.rs
+++ b/test-harness/tests/v0.rs
@@ -5,7 +5,6 @@
 //! * `::` absolute paths -> `rust_demangle_c_test_harness::`
 //! * `#[cfg(unsupported_tests)]` was added to tests that couldn't compile
 //! * `#[ignore = "stack overflow"]` was added to tests that overflow the stack
-//! * Some tests have been split into a non-unicode and a unicode part
 //! * `#[should_panic]` was added to tests that don't pass yet
 
 use rust_demangle_c_test_harness::assert_contains;
@@ -105,12 +104,6 @@ fn demangle_min_const_generics() {
     t_const!("c76_", "'v'");
     t_const!("c22_", r#"'"'"#);
     t_const!("ca_", "'\\n'");
-}
-
-// FIXME(bjorn3) port the relevant functionality to C.
-#[should_panic]
-#[test]
-fn demangle_min_const_generics_unicode() {
     t_const!("c2202_", "'∂'");
 }
 
@@ -119,12 +112,6 @@ fn demangle_const_str() {
     t_const!("e616263_", "{*\"abc\"}");
     t_const!("e27_", r#"{*"'"}"#);
     t_const!("e090a_", "{*\"\\t\\n\"}");
-}
-
-// FIXME(bjorn3) port the relevant functionality to C.
-#[should_panic]
-#[test]
-fn demangle_const_str_unicode() {
     t_const!("ee28882c3bc_", "{*\"∂ü\"}");
     t_const!(
         "ee183a1e18390e183ade1839be18394e1839ae18390e183935fe18392e18394e1839b\
@@ -146,12 +133,6 @@ fn demangle_const_ref_str() {
     t_const!("Re616263_", "\"abc\"");
     t_const!("Re27_", r#""'""#);
     t_const!("Re090a_", "\"\\t\\n\"");
-}
-
-// FIXME(bjorn3) port the relevant functionality to C.
-#[should_panic]
-#[test]
-fn demangle_const_ref_unicode() {
     t_const!("Ree28882c3bc_", "\"∂ü\"");
     t_const!(
         "Ree183a1e18390e183ade1839be18394e1839ae18390e183935fe18392e18394e1839b\

--- a/test-harness/tests/v0.rs
+++ b/test-harness/tests/v0.rs
@@ -223,8 +223,6 @@ fn demangle_exponential_explosion() {
     );
 }
 
-// FIXME(eddyb) port the relevant functionality to C.
-#[should_panic]
 #[test]
 fn demangle_thinlto() {
     t_nohash!("_RC3foo.llvm.9D1C9369", "foo");
@@ -232,8 +230,6 @@ fn demangle_thinlto() {
     t_nohash!("_RNvC9backtrace3foo.llvm.A5310EB9", "backtrace::foo");
 }
 
-// FIXME(eddyb) port the relevant functionality to C.
-#[should_panic]
 #[test]
 fn demangle_extra_suffix() {
     // From alexcrichton/rustc-demangle#27:


### PR DESCRIPTION
These are all necessary to demangle symbols for rustc profiles.